### PR TITLE
feat(cli): implement generate sub-command

### DIFF
--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,11 +1,73 @@
 package cli
 
+import (
+	"fmt"
+	htmltemplate "html/template"
+	"io"
+	"os"
+	texttemplate "text/template"
+
+	"github.com/0xmzn/awlist/internal/awesomestore"
+)
+
 type GenerateCmd struct {
-    InputFile  string `arg:"" required:"" help:"Input template file"`
-    OutputFile string `arg:"" required:"" help:"Output file to write the generated result"`
-	Html bool `help:"Use html mode"`
+	Globals    *Globals `kong:"embed"`
+	InputFile  string   `arg:"" required:"" help:"Input template file"`
+	OutputFile string   `arg:"" optional:"" help:"Output file to write the generated result. Defaults to stdout."`
+	Html       bool     `kong:"optional,name='html',help='Generate HTML output.'"`
 }
 
 func (cmd *GenerateCmd) Run() error {
+	inputFileContent, err := os.ReadFile(cmd.InputFile)
+	if err != nil {
+		return fmt.Errorf("failed to read input file: %w", err)
+	}
+
+	dataPath, err := GetDataFilePath(cmd.Globals.DataFile)
+	if err != nil {
+		return fmt.Errorf("failed to get data file path: %w", err)
+	}
+
+	store, err := awesomestore.NewStore(dataPath)
+	if err != nil {
+		return fmt.Errorf("failed to load data from %s: %w", dataPath, err)
+	}
+
+	awesomeData := store.Data()
+
+	var outputWriter io.Writer
+	if cmd.OutputFile == "" {
+		outputWriter = os.Stdout
+	} else {
+		file, err := os.Create(cmd.OutputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file %s: %w", cmd.OutputFile, err)
+		}
+		defer file.Close()
+		outputWriter = file
+	}
+
+	if cmd.Html {
+		tmpl := htmltemplate.New("user-template-html").Option("missingkey=error")
+		tmpl, err = tmpl.Parse(string(inputFileContent))
+		if err != nil {
+			return fmt.Errorf("html template parsing error: %w", err)
+		}
+		err = tmpl.Execute(outputWriter, awesomeData)
+		if err != nil {
+			return fmt.Errorf("failed to execute html template: %w", err)
+		}
+	} else {
+		tmpl := texttemplate.New("user-template-text").Option("missingkey=error")
+		tmpl, err = tmpl.Parse(string(inputFileContent))
+		if err != nil {
+			return fmt.Errorf("text template parsing error: %w", err)
+		}
+		err = tmpl.Execute(outputWriter, awesomeData)
+		if err != nil {
+			return fmt.Errorf("failed to execute text template: %w", err)
+		}
+	}
+
 	return nil
 }

--- a/internal/cli/helpers.go
+++ b/internal/cli/helpers.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+func GetDataFilePath(providedPath string) (string, error) {
+	if providedPath != "" {
+		if _, err := os.Stat(providedPath); os.IsNotExist(err) {
+			return "", fmt.Errorf("data file specified by --data flag not found: %s", providedPath)
+		}
+		return providedPath, nil
+	}
+
+	if _, err := os.Stat("awesome.yaml"); err == nil {
+		return "awesome.yaml", nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("error checking for awesome.yaml: %w", err)
+	}
+
+	return "", fmt.Errorf("no data file specified and awesome.yaml not found in current directory")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,7 +1,5 @@
 package cli
 
-import "github.com/alecthomas/kong"
-
 type Globals struct {
-    Version kong.VersionFlag `short:"V" help:"Show application version."`
+	DataFile string           `kong:"optional,name='data',short='d',help='Path to the YAML data file. Defaults to awesome.yaml in the current directory if present.'"`
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/alecthomas/kong"
@@ -11,7 +12,7 @@ import (
 var version = "0.1.0"
 
 type App struct {
-	cli.Globals
+	Version  kong.VersionFlag `short:"V" help:"Show application version."`
 	Generate cli.GenerateCmd `cmd:"" help:"generate file from template"`
 }
 
@@ -21,7 +22,7 @@ func main() {
 	}
 
 	var app App
-	parser := kong.Must(&app,
+	parser, err := kong.New(&app,
 		kong.Name("awlist"),
 		kong.Description("A CLI tool for managing awesome-lists"),
 		kong.UsageOnError(),
@@ -30,10 +31,20 @@ func main() {
 		}),
 		kong.Vars{"version": version},
 	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating parser:", err)
+		os.Exit(1)
+	}
 
 	ctx, err := parser.Parse(os.Args[1:])
-	parser.FatalIfErrorf(err)
+	if err != nil {
+		parser.Printf("%v", err)
+		os.Exit(1)
+	}
 
 	err = ctx.Run()
-	ctx.FatalIfErrorf(err)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This commit introduces significant enhancements to the CLI:

- Introducte the generate sub-command
- The generate command loads data from a specified file via the new global --data flag.
- It supports rendering both HTML and text templates.
- Output can be directed to a specified file or defaults to stdout.